### PR TITLE
[Edge] use custom elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "url": "http://github.com/mobify/stencil-select.git"
   },
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "jquery": "^2.1.4"
+  },
   "devDependencies": {
     "grunt": "~0.4.5",
     "grunt-autoprefixer": "2.0.0",
@@ -21,7 +23,7 @@
     "load-grunt-tasks": "~0.4.0",
     "dustjs-linkedin": "2.3.3",
     "requirejs": "^2.1.0",
-    "adaptivejs": "git+ssh://git@github.com:mobify/adaptivejs.git#2.0-stencil",
+    "adaptivejs": "git+ssh://git@github.com:mobify/adaptivejs.git#components",
     "grunt-stencil-dust": "git+ssh://git@github.com:mobify/grunt-stencil-dust.git#master"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,16 +14,17 @@
     "jquery": "^2.1.4"
   },
   "devDependencies": {
+    "adaptivejs": "git+ssh://git@github.com:mobify/adaptivejs.git#components",
+    "document-register-element": "^0.4.3",
+    "dustjs-linkedin": "2.3.3",
     "grunt": "~0.4.5",
     "grunt-autoprefixer": "2.0.0",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-sass": "~0.8.1",
     "grunt-contrib-watch": "^0.6.1",
+    "grunt-stencil-dust": "git+ssh://git@github.com:mobify/grunt-stencil-dust.git#master",
     "load-grunt-tasks": "~0.4.0",
-    "dustjs-linkedin": "2.3.3",
-    "requirejs": "^2.1.0",
-    "adaptivejs": "git+ssh://git@github.com:mobify/adaptivejs.git#components",
-    "grunt-stencil-dust": "git+ssh://git@github.com:mobify/grunt-stencil-dust.git#master"
+    "requirejs": "^2.1.0"
   }
 }

--- a/select.dust
+++ b/select.dust
@@ -1,4 +1,4 @@
-<div class="c-select {class} {?label}c--inner-label{/label}" data-stencil="stencil-select">
+<div class="c-select {class} {?label}c--inner-label{/label}" data-adaptivejs-component="stencil-select">
     {?element}
         {element|s}
     {:else}

--- a/select.dust
+++ b/select.dust
@@ -1,4 +1,4 @@
-<div class="c-select {class} {?label}c--inner-label{/label}" data-adaptivejs-component="stencil-select">
+<stencil-select class="c-select {class} {?label}c--inner-label{/label}" {?disabled}disabled{/disabled}>
     {?element}
         {element|s}
     {:else}
@@ -11,4 +11,4 @@
             {body}
         </select>
     {/element}
-</div>
+</stencil-select>

--- a/select.dust
+++ b/select.dust
@@ -1,4 +1,4 @@
-<stencil-select class="c-select {class} {?label}c--inner-label{/label}" {?disabled}disabled{/disabled}>
+<stencil-select class="c-select {class} {?label}c--inner-label{/label}">
     {?element}
         {element|s}
     {:else}

--- a/select.js
+++ b/select.js
@@ -1,23 +1,21 @@
 define(['$'], function($) {
-    var init = function($el, options) {
-        return new Select($el, options);
-    };
-
     var Select = function Select($el, options) {
-        var self = this;
         this.$el = $el;
         this.value = '';
-        this.$el.on('change component:update', function(event, data) {
-            self.update();
-        });
+
+        $el.on('change', $.proxy(this.update, this));
+
+        this.update();
     }
 
     Select.prototype.update = function update() {
-        this.value = this.$el.find('option:selected').text();
-        this.$el.find('.c-select__value').text(this.value);
+        this.$el.find('.c-select__value').text(this.$el.find('option:selected').text());
+        this.$el.trigger('select:update'); // notify subscribers
     }
 
     return {
-        'init': init
+        'init': function($el, options) {
+            return $el.data('component') || $el.data('component', new Select($el, options));
+        }
     };
 });

--- a/select.js
+++ b/select.js
@@ -1,16 +1,19 @@
 define(['$'], function($) {
     var Select = function Select($el, options) {
-        this.$el = $el;
+        this.dom = {
+            $root: $el,
+            $value: $el.find('.c-select__value')
+        };
         this.value = '';
 
-        $el.on('change', $.proxy(this.update, this));
+        this.dom.$root.on('change', $.proxy(this.update, this));
 
         this.update();
     }
 
     Select.prototype.update = function update() {
-        this.$el.find('.c-select__value').text(this.$el.find('option:selected').text());
-        this.$el.trigger('select:update'); // notify subscribers
+        this.dom.$value.text(this.dom.$root.find('option:selected').text());
+        this.dom.$root.trigger('select:update'); // notify subscribers
     }
 
     return {

--- a/select.js
+++ b/select.js
@@ -1,39 +1,53 @@
 define(function(require) {
-    require('document-register-element'); // Polyfill Custom Elements API
+    // Polyfill Custom Elements API down to Android 2.3
+    require('document-register-element');
+
     var $ = require('$');
     var Select = {};
+
+    // Define a custom property on the component that will sync with the value
+    // of the underlying native select.
+    Select.value = {
+        get: function() {
+            return this.dom.$select.val()
+        },
+        set: function(value) {
+            this.dom.$select.val(value);
+            this.changeCallback();
+        }
+    };
 
     Select.createdCallback = {value: function() {
         console.log('Created <stencil-select> custom element.');
 
-        // The `$` hash contains the component root and any sub-components as
+        // The dom hash contains the component root and any sub-components as
         // selectorLibrary nodes, so they can be operated on with the normal
         // Zepto/jQuery API.
-        this.$ = {
-            root: $(this),
-            value: $(this).find('.c-select__value'),
-            select: $(this).find('select'),
+        this.dom = {
+            $root: $(this),
+            $value: $(this).find('.c-select__value'),
+            $select: $(this).find('select'),
         };
 
         // Event handlers should use $.proxy to preserve access to the instance
         // as `this` within the handler.
-        this.$.root.on('change', $.proxy(this.update, this));
+        this.dom.$root.on('change', 'select', $.proxy(this.changeCallback, this));
 
         // Call any methods here needed on custom element creation.
-        this.update();
+        this.changeCallback();
     }};
 
     Select.attributeChangedCallback = {value: function(name, oldValue, value) {
-        // Sync select attributes from the root node to the embedded select
+        // Sync some attributes from the root node to the embedded select
         // element. This is one-way.
         if (name === 'required' || name === 'disabled') {
-            this.$.select.attr(name, value);
+            this.dom.$select.attr(name, value);
         }
     }};
 
-    Select.update = {value: function() {
-        this.$.value.text(this.$.root.find('option:selected').text());
-        this.$.root.trigger('stencil-select:update'); // notify subscribers
+    Select.changeCallback = {value: function(event) {
+        this.dom.$value.text(this.dom.$select.find('option:selected').text());
+        this.dom.$root.trigger('stencil-select:update'); // notify subscribers
     }};
 
     return document.registerElement('stencil-select', {

--- a/select.js
+++ b/select.js
@@ -1,12 +1,21 @@
-define(function() {
-    var init = function() {
-        $('body').on('change', '.c-select', function() {
-            var $container = $(this);
-            var value = $container.find('option:selected').text();
-
-            $container.find('.c-select__value').text(value);
-        });
+define(['$'], function($) {
+    var init = function($el, options) {
+        return new Select($el, options);
     };
+
+    var Select = function Select($el, options) {
+        var self = this;
+        this.$el = $el;
+        this.value = '';
+        this.$el.on('change component:update', function(event, data) {
+            self.update();
+        });
+    }
+
+    Select.prototype.update = function update() {
+        this.value = this.$el.find('option:selected').text();
+        this.$el.find('.c-select__value').text(this.value);
+    }
 
     return {
         'init': init

--- a/select.js
+++ b/select.js
@@ -1,24 +1,32 @@
-define(['$'], function($) {
-    var Select = function Select($el, options) {
-        this.dom = {
-            $root: $el,
-            $value: $el.find('.c-select__value')
-        };
-        this.value = '';
+define(['$', 'document-register-element'], function($, registerElement) {
+    var selectProto = Object.create(HTMLElement.prototype);
 
-        this.dom.$root.on('change', $.proxy(this.update, this));
+    selectProto.createdCallback = {value: function() {
+        console.log('Created <stencil-select> custom element.');
+
+        this.$ = {
+            root: $(this),
+            value: $(this).find('.c-select__value'),
+            select: $(this).find('select'),
+        };
+
+        this.$.root.on('change', $.proxy(this.update, this));
 
         this.update();
-    }
+    }};
 
-    Select.prototype.update = function update() {
-        this.dom.$value.text(this.dom.$root.find('option:selected').text());
-        this.dom.$root.trigger('select:update'); // notify subscribers
-    }
-
-    return {
-        'init': function($el, options) {
-            return $el.data('component') || $el.data('component', new Select($el, options));
+    selectProto.attributeChangedCallback = {value: function(name, oldValue, value) {
+        if (name === 'disabled' || name === 'required') {
+            value !== null ? this.$.select.attr(name, '') : this.$.select.removeAttr(name);
         }
-    };
+    }};
+
+    selectProto.update = {value: function() {
+        this.$.value.text(this.$.root.find('option:selected').text());
+        this.$.root.trigger('stencil-select:update'); // notify subscribers
+    }};
+
+    return document.registerElement('stencil-select', {
+        prototype: Object.create(HTMLElement.prototype, selectProto)
+    });
 });

--- a/select.js
+++ b/select.js
@@ -1,32 +1,42 @@
-define(['$', 'document-register-element'], function($, registerElement) {
-    var selectProto = Object.create(HTMLElement.prototype);
+define(function(require) {
+    require('document-register-element'); // Polyfill Custom Elements API
+    var $ = require('$');
+    var Select = {};
 
-    selectProto.createdCallback = {value: function() {
+    Select.createdCallback = {value: function() {
         console.log('Created <stencil-select> custom element.');
 
+        // The `$` hash contains the component root and any sub-components as
+        // selectorLibrary nodes, so they can be operated on with the normal
+        // Zepto/jQuery API.
         this.$ = {
             root: $(this),
             value: $(this).find('.c-select__value'),
             select: $(this).find('select'),
         };
 
+        // Event handlers should use $.proxy to preserve access to the instance
+        // as `this` within the handler.
         this.$.root.on('change', $.proxy(this.update, this));
 
+        // Call any methods here needed on custom element creation.
         this.update();
     }};
 
-    selectProto.attributeChangedCallback = {value: function(name, oldValue, value) {
-        if (name === 'disabled' || name === 'required') {
-            value !== null ? this.$.select.attr(name, '') : this.$.select.removeAttr(name);
+    Select.attributeChangedCallback = {value: function(name, oldValue, value) {
+        // Sync select attributes from the root node to the embedded select
+        // element. This is one-way.
+        if (name === 'required' || name === 'disabled') {
+            this.$.select.attr(name, value);
         }
     }};
 
-    selectProto.update = {value: function() {
+    Select.update = {value: function() {
         this.$.value.text(this.$.root.find('option:selected').text());
         this.$.root.trigger('stencil-select:update'); // notify subscribers
     }};
 
     return document.registerElement('stencil-select', {
-        prototype: Object.create(HTMLElement.prototype, selectProto)
+        prototype: Object.create(HTMLElement.prototype, Select)
     });
 });

--- a/select.js
+++ b/select.js
@@ -33,15 +33,39 @@ define(function(require) {
         // as `this` within the handler.
         this.dom.$root.on('change', 'select', $.proxy(this.changeCallback, this));
 
+        // Attribute reflection
+        // TODO This shouldn’t really be set per-instance.
+        this._mirrorAttrs = {
+            disabled: this.dom.$select,
+            required: this.dom.$select,
+        }
+        // TODO This and the mirroring stuff in attributeChangedCallback should
+        // be part of some utility so it can be removed as an authoring concern.
+        for (var attr in this._mirrorAttrs) {
+            if (this._mirrorAttrs.hasOwnProperty(attr)) {
+                this.attributeChangedCallback(attr);
+            }
+        }
+
         // Call any methods here needed on custom element creation.
         this.changeCallback();
     }};
 
     Select.attributeChangedCallback = {value: function(name, oldValue, value) {
-        // Sync some attributes from the root node to the embedded select
-        // element. This is one-way.
-        if (name === 'required' || name === 'disabled') {
-            this.dom.$select.attr(name, value);
+        // Mirror some attributes on change
+        // TODO As noted above, this is too complicated and should be automated
+        // to remove it as an authoring concern.
+        if (this._mirrorAttrs[name]) {
+            var $target = this._mirrorAttrs[name];
+
+            if (value === undefined) {
+                // When there’s no initial value (including when manually on init)
+                // sync from the target node to the root node.
+                this.dom.$root.attr(name, $target.attr(name));
+            } else {
+                // Otherwise, sync from the root to the target.
+                $target.attr(name, value);
+            }
         }
     }};
 

--- a/tests/visual/config.js
+++ b/tests/visual/config.js
@@ -3,6 +3,7 @@ require.config({
         'dust-full': '../../node_modules/dustjs-linkedin/dist/dust-full',
         'adaptivejs': '../../node_modules/adaptivejs',
         '$': '../../node_modules/jquery/dist/jquery',
+        'document-register-element': '../../node_modules/document-register-element/build/document-register-element'
     },
     shim: {
         'dust-full': {

--- a/tests/visual/config.js
+++ b/tests/visual/config.js
@@ -2,10 +2,14 @@ require.config({
     paths: {
         'dust-full': '../../node_modules/dustjs-linkedin/dist/dust-full',
         'adaptivejs': '../../node_modules/adaptivejs',
+        '$': '../../node_modules/jquery/dist/jquery',
     },
     shim: {
         'dust-full': {
             'exports': 'dust'
+        },
+        '$': {
+            'exports': 'jQuery'
         }
     },
 });

--- a/tests/visual/runner.js
+++ b/tests/visual/runner.js
@@ -23,9 +23,9 @@ define(function(require) {
         if (!err) {
             document.querySelector('body').innerHTML = out;
 
-            $('[data-adaptivejs-component="stencil-select"]').each(function(i, el) {
-                ui.init($(el));
-            });
+            // $('[data-adaptivejs-component="stencil-select"]').each(function(i, el) {
+            //     ui.init($(el));
+            // });
         } else {
             console.log(err);
         }

--- a/tests/visual/runner.js
+++ b/tests/visual/runner.js
@@ -2,6 +2,7 @@ define(function(require) {
     var dust = require('dust-full');
     var componentHelper = require('adaptivejs/lib/dust-component-helper');
     var componentSugar = require('adaptivejs/lib/dust-component-sugar');
+    var ui = require('../../select');
     var templates = require('../../tmp/templates');
     var context;
 
@@ -21,6 +22,10 @@ define(function(require) {
     dust.render('tests', context, function(err, out) {
         if (!err) {
             document.querySelector('body').innerHTML = out;
+
+            $('[data-adaptivejs-component="stencil-select"]').each(function(i, el) {
+                ui.init($(el));
+            });
         } else {
             console.log(err);
         }

--- a/tests/visual/runner.js
+++ b/tests/visual/runner.js
@@ -15,7 +15,7 @@ define(function(require) {
     // Define any context required for the tests:
     var context = {
         repo: 'https://github.com/mobify/stencil-select',
-        selectMarkup: '<select id="foo" name="foo"><option value="1">Option 1</option><option value="2">Option 2</option></select>',
+        selectMarkup: '<select id="no2" name="no2"><option value="1">Option 1</option><option value="2">Option 2</option></select>',
     };
 
     // Render

--- a/tests/visual/tests.dust
+++ b/tests/visual/tests.dust
@@ -5,7 +5,7 @@
 {@c-spec for="Select Component" repository=repo}
     {@c-spec__test describe=".c-select"}
         {@c-spec__case expect="It should create a custom styled select box."}
-            {@c-select id="foo" name="foo"}
+            {@c-select id="no1" name="no1"}
                 <option value="1">Option 1</option>
                 <option value="2">Option 2</option>
                 <option value="3">Option 3</option>
@@ -18,7 +18,7 @@
         {/c-spec__case}
 
         {@c-spec__case expect="Optionally, it can include an inner label."}
-            {@c-select id="bar" name="bar" label="Inner Label" value="1"}
+            {@c-select id="no3" name="no3" label="Inner Label" value="1"}
                 <option value="1">Option 1</option>
                 <option value="2">Option 2</option>
                 <option value="3">Option 3</option>
@@ -27,7 +27,7 @@
         {/c-spec__case}
 
         {@c-spec__case expect="Optionally, it can include an inner label."}
-            {@c-select id="bar" name="bar" label="Inner Label" value="1" disabled="true"}
+            {@c-select id="no4" name="no4" label="Inner Label" value="1" disabled="true"}
                 <option value="1">Option 1</option>
                 <option value="2">Option 2</option>
                 <option value="3">Option 3</option>

--- a/tests/visual/tests.dust
+++ b/tests/visual/tests.dust
@@ -25,5 +25,14 @@
                 <option value="4">Option 4</option>
             {/c-select}
         {/c-spec__case}
+
+        {@c-spec__case expect="Optionally, it can include an inner label."}
+            {@c-select id="bar" name="bar" label="Inner Label" value="1" disabled="true"}
+                <option value="1">Option 1</option>
+                <option value="2">Option 2</option>
+                <option value="3">Option 3</option>
+                <option value="4">Option 4</option>
+            {/c-select}
+        {/c-spec__case}
     {/c-spec__test}
 {/c-spec}

--- a/tests/visual/tests.dust
+++ b/tests/visual/tests.dust
@@ -27,7 +27,7 @@
         {/c-spec__case}
 
         {@c-spec__case expect="Optionally, it can include an inner label."}
-            {@c-select id="no4" name="no4" label="Inner Label" value="1" disabled="true"}
+            {@c-select id="no4" name="no4" label="Inner Label" value="1" required="true"}
                 <option value="1">Option 1</option>
                 <option value="2">Option 2</option>
                 <option value="3">Option 3</option>


### PR DESCRIPTION
We want components to be initialized automatically once they’re in the page. This was tough to do, and currently requires a `data-` attribute, some dom traversal, and hooks into the internal Adaptive component registry.

Also, for things like this Select component, it would be nice if it behaved more like a real `<select>` element, with attributes like `disabled` and `required`.

One alternative way to address these would be to use the only part of the Web Components spec that is actually feasible to use today: Custom Elements. There is a [lightweight polyfill](https://github.com/WebReflection/document-register-element) (3KB min+gzip) available that works back to Android 2.2, although runtime performance profiling on old Android would be needed before seriously considering it.

Also of note: this means we would not be able to pass in an options object or initialize component in view UI. As per [Web Components best practices](http://webcomponents.org/articles/web-components-best-practices/), we would be using “HTML attributes for data in and events for data out”. I think this is fine as long as the component exposes a sufficient API (methods) for interacting with it.

Status: **DONUT MERGE**

Reviewers: @fractaltheory @donnielrt 
Ticket: N/A
Linked PRs: N/A
## Changes
- Use a Custom Elements polyfill, and make the Select root node a custom element, `stencil-select`.
- Add a `value` property to the component: it’s a getter/setter just like `someSelectNode.value`, and because it mirrors the property name of the native select element, doing `$('stencil-select').eq(0).val()` also works.
- Add some (currently kludgy) code to sync the `required` and `disabled` attributes from the custom element to the underlying select element. Values are initialized based on the underlying select, so they can’t start out of  sync.
## How to test drive this PR
- Check out this branch
- Delete node_modules and do a fresh `npm install`
- Run `grunt` and look for the port the server is using
- Open `http://localhost:{port}/tests/visual`
- Change the value of the third select instance and ensure it updates
- Set the `disabled` attribute on one of the custom elements. Notice the underlying select element updates.
- Add a new `stencil-select` element to the dom in the inspector (manually pasting HTML works). Notice that it is automatically initialized and works as expected.
## Research Resources
- https://github.com/WebReflection/document-register-element
- http://developer.telerik.com/featured/web-components-ready-production/
